### PR TITLE
Whitelist aria and data attributes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,11 @@ const eventProps = {
 };
 
 function isValidDOMProp(prop) {
-	return eventProps[prop] || htmlAttributes[prop];
+	return (
+		eventProps[prop] ||
+		htmlAttributes[prop] ||
+		/^(data|aria)-/.test(prop)
+	);
 }
 
 export default function filterInvalidDOMProps(props) {

--- a/test/index.js
+++ b/test/index.js
@@ -6,13 +6,17 @@ test("it should filter invalid properties and leave valid ones", assert => {
 		onClick: () => {},
 		value: "cool",
 		type: "text",
-		christophercolumbus: "notcool"
+		christophercolumbus: "notcool",
+		"aria-label": "accessible",
+		"data-extra": "smart"
 	};
 	const filteredProps = filterDOMProps(properties);
-	assert.equal(Object.keys(filteredProps).length, 3);
+	assert.equal(Object.keys(filteredProps).length, 5);
 	assert.equal(filteredProps.value, properties.value);
 	assert.equal(filteredProps.onClick, properties.onClick);
 	assert.equal(filteredProps.type, properties.type);
+	assert.equal(filteredProps["aria-label"], properties["aria-label"]);
+	assert.equal(filteredProps["data-extra"], properties["data-extra"]);
 	assert.notEqual(filteredProps.christophercolumbus, properties.christophercolumbus);
 	assert.end();
 });


### PR DESCRIPTION
There's a very long list of `aria` attributes the `html-attributes` library doesn't include as well as an infinite list of `data` attributes. Considering these always need to be specified with dashes, it should be safe to simply whitelist them by prefix. This PR does exactly that.