### PR TITLE
Republish under org name

### DIFF
--- a/.changeset/fluffy-trains-wash.md
+++ b/.changeset/fluffy-trains-wash.md
@@ -1,0 +1,5 @@
+---
+"@socialtables/filter-invalid-dom-props": major
+---
+
+Publish new package scoped to `@socialtables` org

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 [![CircleCI](https://circleci.com/gh/socialtables/filter-invalid-dom-props.svg?style=svg)](https://circleci.com/gh/socialtables/filter-invalid-dom-props)
 
+Formerly `filter-invalid-dom-props` on npm. Now `@socialtables/filter-invalid-dom-props`.
+
 A simple helper function to filter out invalid dom properties. Useful when spreading into at html element in react applications (and maybe for other things).
 
 ## Use
 
 ```js
-import filterInvalidDOMProps from "filter-invalid-dom-props";
+import filterInvalidDOMProps from "@socialtables/filter-invalid-dom-props";
 const properties = {
 	onClick: () => {},
 	value: "cool",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "filter-invalid-dom-props",
-  "version": "3.0.0",
+  "name": "@socialtables/filter-invalid-dom-props",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "filter-invalid-dom-props",
-  "version": "3.0.0",
+  "name": "@socialtables/filter-invalid-dom-props",
+  "version": "2.0.0",
   "description": "a function to filter props that are not valid dom props when spreading props in an HOC in react",
   "main": "dist/index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
We have lost permissions/access to continue publishing to the original npm package. It's now moved to `@socialtables/`
