### PR TITLE
add loading prop to be used for <img> tags

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,7 @@ const htmlAttributes = {
 	label: "label",
 	lang: "lang",
 	list: "list",
+	loading: "loading",
 	loop: "loop",
 	manifest: "manifest",
 	max: "max",


### PR DESCRIPTION
ReactFallbackImage filters out the loading="lazy" I'm trying to add